### PR TITLE
添加支持 7kW交流充电桩(乐享智联款)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ cp -r hass-iotbull/custom_components/bull ~/hass/custom_components
 | 75 | 7kW交流充电桩(风尚智联款) |
 | 141 | 21kW交流充电桩(风尚智联款) |
 | 196 | 单相7kW充电桩(乐享款) |
+| 258 | 7kW交流充电桩(乐享智联款) |
 
 ### 窗帘
 

--- a/custom_components/bull/__init__.py
+++ b/custom_components/bull/__init__.py
@@ -4,6 +4,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.service import async_register_admin_service
 
+from .api import BullApi
 from .const import (
     DOMAIN,
     BULL_API_CLIENTS,
@@ -35,9 +36,8 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Bull IoT integration from a config entry."""
-    from .api import BullApi
 
-    bull_api = BullApi(hass, entry.data, entry=entry)
+    bull_api = BullApi(hass, entry.data)
 
     await bull_api.setup()
     hass.data[DOMAIN][BULL_API_CLIENTS][entry.entry_id] = bull_api

--- a/custom_components/bull/__init__.py
+++ b/custom_components/bull/__init__.py
@@ -4,7 +4,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.service import async_register_admin_service
 
-from .api import BullApi
 from .const import (
     DOMAIN,
     BULL_API_CLIENTS,
@@ -36,7 +35,9 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Bull IoT integration from a config entry."""
-    bull_api = BullApi(hass, entry.data)
+    from .api import BullApi
+
+    bull_api = BullApi(hass, entry.data, entry=entry)
 
     await bull_api.setup()
     hass.data[DOMAIN][BULL_API_CLIENTS][entry.entry_id] = bull_api

--- a/custom_components/bull/api.py
+++ b/custom_components/bull/api.py
@@ -93,8 +93,38 @@ class BullDevice:
     async def set_dp(self, identifier: str, prop: int):
         await self._cloud.set_property(self.iot_id, identifier, prop)
 
+    def _sync_raw_info_value(self, identifier: str, value) -> None:
+        """Sync incremental MQTT value into raw_info property snapshot."""
+        raw_info = getattr(self, "raw_info", None)
+        if not isinstance(raw_info, dict):
+            return
+
+        properties = raw_info.get("property")
+        if not isinstance(properties, dict):
+            return
+
+        if identifier == "status":
+            raw_info["status"] = value
+            return
+
+        if "." not in identifier:
+            prop_entry = properties.get(identifier)
+            if isinstance(prop_entry, dict):
+                prop_entry["value"] = value
+            return
+
+        parent_identifier, child_identifier = identifier.split(".", 1)
+        parent_entry = properties.get(parent_identifier)
+        if not isinstance(parent_entry, dict):
+            return
+
+        parent_value = parent_entry.get("value")
+        if isinstance(parent_value, dict):
+            parent_value[child_identifier] = value
+
     def update_dp(self, identifier: str, prop):
         self.identifier_values[identifier] = prop
+        self._sync_raw_info_value(identifier, prop)
         if self._connectivity_entity:
             self._connectivity_entity.schedule_update_ha_state()
 
@@ -112,6 +142,7 @@ class BullSwitch(BullDevice):
 
     def update_dp(self, identifier: str, prop):
         self.identifier_values[identifier] = prop
+        self._sync_raw_info_value(identifier, prop)
         entity = self._entities.get(identifier)
         if entity:
             entity.schedule_update_ha_state()
@@ -130,6 +161,7 @@ class BullCover(BullDevice):
 
     def update_dp(self, identifier: str, prop):
         self.identifier_values[identifier] = prop
+        self._sync_raw_info_value(identifier, prop)
         entity = self._entity
         if entity:
             entity.schedule_update_ha_state()

--- a/custom_components/bull/api.py
+++ b/custom_components/bull/api.py
@@ -363,7 +363,10 @@ class BullApi:
         device.raw_info = info
         for prop in info["property"].values():
             key = prop["identifier"]
-            device.identifier_values[key] = prop["value"]
+            for flattened_key, flattened_value in self._flatten_identifier_values(
+                key, prop["value"]
+            ).items():
+                device.identifier_values[flattened_key] = flattened_value
         device_info = await self.async_get_device_info(device.iot_id)
         device.raw_device_info = device_info
         device.product_name = device_info["productName"]
@@ -372,6 +375,13 @@ class BullApi:
         # Use productName as the default nick_name (reliable fallback)
         device.nick_name = device.product_name
 
+    def _flatten_identifier_values(self, identifier: str, value) -> dict:
+        """Return flat identifier-value mapping for legacy and nested sensor mapping."""
+        flattened = {identifier: value}
+        if isinstance(value, dict):
+            for child_identifier, child_value in value.items():
+                flattened[f"{identifier}.{child_identifier}"] = child_value
+        return flattened
     async def async_parse_devices(self, db) -> None:
         """Parse the devices information."""
         for info in db["result"]:
@@ -461,7 +471,10 @@ class BullApi:
                 iot_id = db["params"]["iotId"]
                 items = db["params"]["items"]
                 for identifier, info in items.items():
-                    cb(iot_id, identifier, info["value"])
+                    for flattened_key, flattened_value in self._flatten_identifier_values(
+                        identifier, info["value"]
+                    ).items():
+                        cb(iot_id, flattened_key, flattened_value)
             elif db.get("method") == "thing.status":
                 iot_id = db["params"]["iotId"]
                 info = db["params"]["status"]

--- a/custom_components/bull/api.py
+++ b/custom_components/bull/api.py
@@ -78,6 +78,9 @@ class BullDevice:
         # float (indicating socket power etc.)
         # string (indication device online etc.)
         self.identifier_values = {}
+        self.raw_info = {}
+        self.raw_device_info = {}
+        self._connectivity_entity = None
 
     @property
     def available(self) -> bool:
@@ -85,13 +88,15 @@ class BullDevice:
         # status is ONLINE or OFFLINE from /v2/home/devices API
         # It may change to int from thing.status mqtt message
         # 1 - Online, 3 - Offline
-        return self.identifier_values["status"] in ["ONLINE", 1]
+        return self.identifier_values.get("status") in ["ONLINE", 1]
 
     async def set_dp(self, identifier: str, prop: int):
         await self._cloud.set_property(self.iot_id, identifier, prop)
 
     def update_dp(self, identifier: str, prop):
-        pass
+        self.identifier_values[identifier] = prop
+        if self._connectivity_entity:
+            self._connectivity_entity.schedule_update_ha_state()
 
 
 class BullSwitch(BullDevice):
@@ -110,6 +115,8 @@ class BullSwitch(BullDevice):
         entity = self._entities.get(identifier)
         if entity:
             entity.schedule_update_ha_state()
+        if self._connectivity_entity:
+            self._connectivity_entity.schedule_update_ha_state()
         _LOGGER.debug("Update device property: %s %s %s", self.iot_id, identifier, prop)
 
 
@@ -126,6 +133,8 @@ class BullCover(BullDevice):
         entity = self._entity
         if entity:
             entity.schedule_update_ha_state()
+        if self._connectivity_entity:
+            self._connectivity_entity.schedule_update_ha_state()
         _LOGGER.debug("Update device property: %s %s %s", self.iot_id, identifier, prop)
 
 
@@ -340,8 +349,9 @@ class BullApi:
         elif global_product_id in COVER_PRODUCT_ID:
             device.name = info.get("nickName", device.nick_name)
         else:
-            _LOGGER.warning(
-                "Unsupported device: %s %s %s",
+            _LOGGER.info(
+                "Unknown product %s, keep connectivity entity only: %s %s %s",
+                global_product_id,
                 device.iot_id,
                 device.product_name,
                 device.model_name,
@@ -350,10 +360,12 @@ class BullApi:
     async def async_add_new_device(self, device: BullDevice, info: dict) -> None:
         """Add a new device to the device list."""
         self.device_list[device.iot_id] = device
+        device.raw_info = info
         for prop in info["property"].values():
             key = prop["identifier"]
             device.identifier_values[key] = prop["value"]
         device_info = await self.async_get_device_info(device.iot_id)
+        device.raw_device_info = device_info
         device.product_name = device_info["productName"]
         device.model_name = device_info["modelName"]
         device.firmware_version = device_info["firmwareVersion"]

--- a/custom_components/bull/binary_sensor.py
+++ b/custom_components/bull/binary_sensor.py
@@ -82,6 +82,7 @@ class BullConnectivityBinarySensorEntity(BinarySensorEntity):
         attrs = {}
         attrs.update(_flatten_dict(getattr(self._device, "raw_info", {}), "info"))
         attrs.update(_flatten_dict(getattr(self._device, "raw_device_info", {}), "device_info"))
+        attrs.update(_flatten_dict(getattr(self._device, "identifier_values", {}), "realtime"))
         return attrs
 
 

--- a/custom_components/bull/binary_sensor.py
+++ b/custom_components/bull/binary_sensor.py
@@ -1,15 +1,18 @@
 """Entity definition for binary sensor devices."""
 
+from typing import Any
+
 from homeassistant.components.binary_sensor import (
-    BinarySensorEntity,
     BinarySensorDeviceClass,
+    BinarySensorEntity,
 )
-from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, BULL_API_CLIENTS
 from .api import BullDevice
+from .const import BULL_API_CLIENTS, DOMAIN
 
 
 def _flatten_dict(data: dict, prefix: str = "") -> dict:
@@ -33,53 +36,44 @@ def _flatten_dict(data: dict, prefix: str = "") -> dict:
 class BullConnectivityBinarySensorEntity(BinarySensorEntity):
     """Representation of a Bull IoT connectivity binary sensor."""
 
+    _attr_has_entity_name = True
+    _attr_translation_key = "connectivity"
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    _attr_icon = "mdi:devices"
+
     def __init__(self, device: BullDevice) -> None:
         self._device = device
         self._attr_should_poll = False
+        self._attr_unique_id = f"{self._device.iot_id}.connectivity"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self._device.iot_id)},
+            name=f"{self._device.room}{self._device.nick_name}",
+            manufacturer="Bull",
+            model=self._device.product_name,
+            model_id=self._device.model_name,
+            serial_number=self._device.iot_id,
+            suggested_area=self._device.room,
+            sw_version=self._device.firmware_version,
+        )
         self._device._connectivity_entity = self
 
     @property
-    def device_info(self):
-        return {
-            "identifiers": {
-                # Serial numbers are unique identifiers within a specific domain
-                (DOMAIN, self._device.iot_id)
-            },
-            "name": f"{self._device.room}{self._device.nick_name}",
-            "manufacturer": "Bull",
-            "model": self._device.product_name,
-            "model_id": self._device.model_name,
-            "serial_number": self._device.iot_id,
-            "suggested_area": self._device.room,
-            "sw_version": self._device.firmware_version,
-        }
-
-    @property
-    def unique_id(self) -> str:
-        return self._device.iot_id + ".connectivity"
-
-    @property
-    def name(self) -> str:
-        return f"连通性"
-
-    @property
-    def device_class(self):
-        return BinarySensorDeviceClass.CONNECTIVITY
-
-    @property
     def available(self) -> bool:
-        """Return True if the device is available."""
-        return self._device.available
+        """Return whether this entity is available."""
+        return True
 
     @property
     def is_on(self) -> bool:
-        """Return if the device is connected."""
-        return self._device.available
+        """Return if connectivity is online."""
+        raw_info = getattr(self._device, "raw_info", {})
+        if not isinstance(raw_info, dict):
+            return False
+        return raw_info.get("status") == "ONLINE"
 
     @property
-    def extra_state_attributes(self) -> dict:
+    def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra state attributes."""
-        attrs = {}
+        attrs: dict[str, Any] = {}
         attrs.update(_flatten_dict(getattr(self._device, "raw_info", {}), "info"))
         attrs.update(_flatten_dict(getattr(self._device, "raw_device_info", {}), "device_info"))
         attrs.update(_flatten_dict(getattr(self._device, "identifier_values", {}), "realtime"))

--- a/custom_components/bull/binary_sensor.py
+++ b/custom_components/bull/binary_sensor.py
@@ -1,0 +1,100 @@
+"""Entity definition for binary sensor devices."""
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorEntity,
+    BinarySensorDeviceClass,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN, BULL_API_CLIENTS
+from .api import BullDevice
+
+
+def _flatten_dict(data: dict, prefix: str = "") -> dict:
+    flattened = {}
+    for key, value in data.items():
+        flat_key = f"{prefix}.{key}" if prefix else str(key)
+        if isinstance(value, dict):
+            flattened.update(_flatten_dict(value, flat_key))
+        elif isinstance(value, list):
+            for index, item in enumerate(value):
+                list_key = f"{flat_key}.{index}"
+                if isinstance(item, dict):
+                    flattened.update(_flatten_dict(item, list_key))
+                else:
+                    flattened[list_key] = item
+        else:
+            flattened[flat_key] = value
+    return flattened
+
+
+class BullConnectivityBinarySensorEntity(BinarySensorEntity):
+    """Representation of a Bull IoT connectivity binary sensor."""
+
+    def __init__(self, device: BullDevice) -> None:
+        self._device = device
+        self._attr_should_poll = False
+        self._device._connectivity_entity = self
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {
+                # Serial numbers are unique identifiers within a specific domain
+                (DOMAIN, self._device.iot_id)
+            },
+            "name": f"{self._device.room}{self._device.nick_name}",
+            "manufacturer": "Bull",
+            "model": self._device.product_name,
+            "model_id": self._device.model_name,
+            "serial_number": self._device.iot_id,
+            "suggested_area": self._device.room,
+            "sw_version": self._device.firmware_version,
+        }
+
+    @property
+    def unique_id(self) -> str:
+        return self._device.iot_id + ".connectivity"
+
+    @property
+    def name(self) -> str:
+        return f"连通性"
+
+    @property
+    def device_class(self):
+        return BinarySensorDeviceClass.CONNECTIVITY
+
+    @property
+    def available(self) -> bool:
+        """Return True if the device is available."""
+        return self._device.available
+
+    @property
+    def is_on(self) -> bool:
+        """Return if the device is connected."""
+        return self._device.available
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Return extra state attributes."""
+        attrs = {}
+        attrs.update(_flatten_dict(getattr(self._device, "raw_info", {}), "info"))
+        attrs.update(_flatten_dict(getattr(self._device, "raw_device_info", {}), "device_info"))
+        return attrs
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Bull IoT binary sensor platform."""
+    bull_api = hass.data[DOMAIN][BULL_API_CLIENTS][config_entry.entry_id]
+    entities = []
+
+    for device in bull_api.device_list.values():
+        entities.append(BullConnectivityBinarySensorEntity(device))
+
+    async_add_entities(entities, update_before_add=False)

--- a/custom_components/bull/binary_sensor.py
+++ b/custom_components/bull/binary_sensor.py
@@ -68,7 +68,7 @@ class BullConnectivityBinarySensorEntity(BinarySensorEntity):
         raw_info = getattr(self._device, "raw_info", {})
         if not isinstance(raw_info, dict):
             return False
-        return raw_info.get("status") == "ONLINE"
+        return raw_info.get("status") in ("ONLINE", 1)
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/custom_components/bull/const.py
+++ b/custom_components/bull/const.py
@@ -95,23 +95,20 @@ SENSOR_MAPPING = {
             "name": "当前充电量",
             "unit": UnitOfEnergy.KILO_WATT_HOUR,
             "class": "energy",
-            "scale": 100,
         },
         "Current": {
             "name": "实时电流",
             "unit": UnitOfElectricCurrent.AMPERE,
             "class": "current",
-            "scale": 100,
         },
         "Voltage": {
             "name": "实时电压",
             "unit": UnitOfElectricPotential.VOLT,
             "class": "voltage",
-            "scale": 10,
         },
         "ActivePower": {
             "name": "实时功率",
-            "unit": UnitOfPower.WATT,
+            "unit": UnitOfPower.KILO_WATT,
             "class": "power"
         },
         "GunTemp": {
@@ -136,8 +133,10 @@ SENSOR_MAPPING = {
             "unit": None,
             "class": None,
             "value_map": {
-                0: "未充电",
-                1: "充电中",
+                0: "未工作",
+                2: "充电中",
+                8: "已插枪未激活",
+                9: "已插枪已激活",
             },
         },
         "GunState": {

--- a/custom_components/bull/const.py
+++ b/custom_components/bull/const.py
@@ -6,6 +6,7 @@ from homeassistant.const import (
     UnitOfElectricCurrent,
     UnitOfEnergy,
     UnitOfTime,
+    UnitOfTemperature,
     SERVICE_RELOAD,
 )
 
@@ -38,7 +39,7 @@ SWITCH_PRODUCT_ID = {
     180,
     279,
 }
-CHARGER_PRODUCT_ID = {74, 75, 141, 196}
+CHARGER_PRODUCT_ID = {74, 75, 141, 196, 258}
 COVER_PRODUCT_ID = {31, 56}
 
 SENSOR_MAPPING = {
@@ -80,4 +81,64 @@ SENSOR_MAPPING = {
         "class": "energy",
         "scale": 100,
     },
+    "DeviceRealInfo": {
+        "EnergyUsed": {
+            "name": "当前充电量",
+            "unit": UnitOfEnergy.KILO_WATT_HOUR,
+            "class": "energy",
+            "scale": 100,
+        },
+        "Current": {
+            "name": "实时电流",
+            "unit": UnitOfElectricCurrent.AMPERE,
+            "class": "current",
+            "scale": 100,
+        },
+        "Voltage": {
+            "name": "实时电压",
+            "unit": UnitOfElectricPotential.VOLT,
+            "class": "voltage",
+            "scale": 10,
+        },
+        "ActivePower": {
+            "name": "实时功率",
+            "unit": UnitOfPower.WATT,
+            "class": "power"
+        },
+        "GunTemp": {
+            "name": "枪头温度",
+            "unit": UnitOfTemperature.CELSIUS,
+            "class": "temperature",
+        },
+        "SlotTemp": {
+            "name": "插座温度",
+            "unit": UnitOfTemperature.CELSIUS,
+            "class": "temperature",
+        },
+        "MBTemp": {
+            "name": "主板温度",
+            "unit": UnitOfTemperature.CELSIUS,
+            "class": "temperature",
+        },
+    },
+    "DeviceWorkState": {
+        "WorkState": {
+            "name": "充电状态",
+            "unit": None,
+            "class": None,
+            "value_map": {
+                0: "未充电",
+                1: "充电中",
+            },
+        },
+        "GunState": {
+            "name": "插枪状态",
+            "unit": None,
+            "class": None,
+            "value_map": {
+                0: "未插枪",
+                1: "已插枪",
+            },
+        },
+    }
 }

--- a/custom_components/bull/const.py
+++ b/custom_components/bull/const.py
@@ -81,6 +81,15 @@ SENSOR_MAPPING = {
         "class": "energy",
         "scale": 100,
     },
+    "ChargeMode": {
+        "name": "充电模式",
+        "unit": None,
+        "class": None,
+        "value_map": {
+            0: "即插即充",
+            1: "无感充电",
+        },
+    },
     "DeviceRealInfo": {
         "EnergyUsed": {
             "name": "当前充电量",

--- a/custom_components/bull/const.py
+++ b/custom_components/bull/const.py
@@ -11,7 +11,7 @@ from homeassistant.const import (
 
 DOMAIN = "bull"
 BULL_API_CLIENTS = "bull_api_clients"
-SUPPORTED_PLATFORMS = ["switch", "sensor", "cover"]
+SUPPORTED_PLATFORMS = ["switch", "sensor", "cover", "binary_sensor"]
 
 APPSECRET = b"t3f9hqri8ciuici50aem25xmcyqsopey"
 API_URL = "https://api.iotbull.com"

--- a/custom_components/bull/device_trigger.py
+++ b/custom_components/bull/device_trigger.py
@@ -1,0 +1,139 @@
+"""Device triggers for Bull integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
+from homeassistant.components.homeassistant.triggers.state import (
+    async_attach_trigger as async_attach_state_trigger,
+)
+from homeassistant.const import (
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_ENTITY_ID,
+    CONF_FOR,
+    CONF_PLATFORM,
+    CONF_TYPE,
+)
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
+
+from .const import DOMAIN
+
+TRIGGER_TYPES = {
+    "work_state_idle": {
+        "sensor_key": "DeviceWorkState.WorkState",
+        "to": "未工作",
+    },
+    "work_state_charging": {
+        "sensor_key": "DeviceWorkState.WorkState",
+        "to": "充电中",
+    },
+    "work_state_gun_inserted_not_activated": {
+        "sensor_key": "DeviceWorkState.WorkState",
+        "to": "已插枪未激活",
+    },
+    "work_state_gun_inserted_activated": {
+        "sensor_key": "DeviceWorkState.WorkState",
+        "to": "已插枪已激活",
+    },
+    "gun_state_unplugged": {
+        "sensor_key": "DeviceWorkState.GunState",
+        "to": "未插枪",
+    },
+    "gun_state_plugged": {
+        "sensor_key": "DeviceWorkState.GunState",
+        "to": "已插枪",
+    },
+}
+
+TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_TYPE): vol.In(TRIGGER_TYPES),
+        vol.Required(CONF_ENTITY_ID): str,
+        vol.Optional(CONF_FOR): cv.positive_time_period_dict,
+    }
+)
+
+
+async def async_get_triggers(hass: HomeAssistant, device_id: str) -> list[dict[str, Any]]:
+    """List device triggers for a Bull device."""
+    registry = er.async_get(hass)
+    entries = er.async_entries_for_device(
+        registry,
+        device_id,
+        include_disabled_entities=False,
+    )
+
+    entities_by_key: dict[str, str] = {}
+    for entry in entries:
+        if entry.domain != "sensor":
+            continue
+        if not entry.unique_id:
+            continue
+        if entry.unique_id.endswith("DeviceWorkState.WorkState"):
+            entities_by_key["DeviceWorkState.WorkState"] = entry.entity_id
+        elif entry.unique_id.endswith("DeviceWorkState.GunState"):
+            entities_by_key["DeviceWorkState.GunState"] = entry.entity_id
+
+    triggers: list[dict[str, Any]] = []
+    for trigger_type, config in TRIGGER_TYPES.items():
+        entity_id = entities_by_key.get(config["sensor_key"])
+        if not entity_id:
+            continue
+        triggers.append(
+            {
+                CONF_PLATFORM: "device",
+                CONF_DOMAIN: DOMAIN,
+                CONF_DEVICE_ID: device_id,
+                CONF_ENTITY_ID: entity_id,
+                CONF_TYPE: trigger_type,
+            }
+        )
+
+    return triggers
+
+
+async def async_get_trigger_capabilities(
+    hass: HomeAssistant, config: dict[str, Any]
+) -> dict[str, vol.Schema]:
+    """List trigger capabilities."""
+    return {
+        "extra_fields": vol.Schema(
+            {vol.Optional(CONF_FOR): cv.positive_time_period_dict}
+        )
+    }
+
+
+async def async_attach_trigger(
+    hass: HomeAssistant,
+    config: dict[str, Any],
+    action: TriggerActionType,
+    trigger_info: TriggerInfo,
+) -> CALLBACK_TYPE:
+    """Attach a trigger."""
+    trigger = TRIGGER_TYPES[config[CONF_TYPE]]
+
+    state_config: dict[str, Any] = {
+        CONF_PLATFORM: "state",
+        CONF_ENTITY_ID: config[CONF_ENTITY_ID],
+    }
+    if "to" in trigger:
+        state_config["to"] = trigger["to"]
+    if "from" in trigger:
+        state_config["from"] = trigger["from"]
+    if CONF_FOR in config:
+        state_config[CONF_FOR] = config[CONF_FOR]
+
+    return await async_attach_state_trigger(
+        hass,
+        state_config,
+        action,
+        trigger_info,
+        platform_type="device",
+    )

--- a/custom_components/bull/sensor.py
+++ b/custom_components/bull/sensor.py
@@ -16,17 +16,43 @@ from .const import (
 from .api import BullSwitch
 
 
+def _is_sensor_meta(value) -> bool:
+    return isinstance(value, dict) and {"name", "unit", "class"}.issubset(value.keys())
+
+
+def _iter_sensor_specs(mapping: dict):
+    """Yield normalized sensor specs as (entity_identifier, value_key, meta)."""
+    for identifier, config in mapping.items():
+        if _is_sensor_meta(config):
+            yield identifier, identifier, config
+            continue
+
+        if isinstance(config, dict):
+            for child_identifier, child_config in config.items():
+                if _is_sensor_meta(child_config):
+                    key = f"{identifier}.{child_identifier}"
+                    yield key, key, child_config
+
+
 class BullSensorEntity(SensorEntity):
     """Representation of a Bull IoT sensor."""
 
-    def __init__(self, device: BullSwitch, identifier: str):
+    def __init__(
+        self,
+        device: BullSwitch,
+        entity_identifier: str,
+        value_key: str,
+        meta: dict,
+    ):
         self._device = device
-        self._identifier = identifier
-        self._attr_device_class = SENSOR_MAPPING[self._identifier]["class"]
-        self._attr_native_unit_of_measurement = SENSOR_MAPPING[self._identifier]["unit"]
+        self._entity_identifier = entity_identifier
+        self._value_key = value_key
+        self._meta = meta
+        self._attr_device_class = self._meta["class"]
+        self._attr_native_unit_of_measurement = self._meta["unit"]
         if self._attr_device_class == "energy":
             self._attr_state_class = SensorStateClass.TOTAL_INCREASING
-        device._entities[identifier] = self
+        device._entities[value_key] = self
 
     @property
     def device_info(self):
@@ -46,12 +72,12 @@ class BullSensorEntity(SensorEntity):
 
     @property
     def unique_id(self) -> str:
-        return self._device.iot_id + "." + self._identifier
+        return self._device.iot_id + "." + self._entity_identifier
 
     @property
     def name(self):
         # FIXME: may not work
-        return f"{list(self._device.identifier_names.values())[0]}{SENSOR_MAPPING[self._identifier]['name']}"
+        return f"{list(self._device.identifier_names.values())[0]}{self._meta['name']}"
 
     @property
     def available(self) -> bool:
@@ -60,9 +86,11 @@ class BullSensorEntity(SensorEntity):
 
     @property
     def native_value(self):
-        value = self._device.identifier_values[self._identifier]
-        if "scale" in SENSOR_MAPPING[self._identifier]:
-            value /= SENSOR_MAPPING[self._identifier]["scale"]
+        value = self._device.identifier_values[self._value_key]
+        if "value_map" in self._meta:
+            value = self._meta["value_map"].get(value, value)
+        if "scale" in self._meta:
+            value /= self._meta["scale"]
         return value
 
 
@@ -74,10 +102,14 @@ async def async_setup_entry(
     """Set up the Bull IoT platform."""
     bull_api = hass.data[DOMAIN][BULL_API_CLIENTS][config_entry.entry_id]
     entities = []
+    sensor_specs = list(_iter_sensor_specs(SENSOR_MAPPING))
+
     for device in bull_api.device_list.values():
         if device.global_product_id in SWITCH_PRODUCT_ID | CHARGER_PRODUCT_ID:
-            for identifier in SENSOR_MAPPING:
-                if identifier in device.identifier_values:
-                    entities.append(BullSensorEntity(device, identifier))
+            for entity_identifier, value_key, meta in sensor_specs:
+                if value_key in device.identifier_values:
+                    entities.append(
+                        BullSensorEntity(device, entity_identifier, value_key, meta)
+                    )
 
     async_add_entities(entities, update_before_add=False)

--- a/custom_components/bull/switch.py
+++ b/custom_components/bull/switch.py
@@ -94,7 +94,7 @@ async def async_setup_entry(
             for identifier in device.identifier_names:
                 entities.append(BullSwitchEntity(device, identifier))
         elif device.global_product_id in CHARGER_PRODUCT_ID:
-            for identifier in device.identifier_names:
-                entities.append(BullChargerEntity(device, identifier))
+            if "ChargeSwitch" in device.identifier_names:
+                entities.append(BullChargerEntity(device, "ChargeSwitch"))
 
     async_add_entities(entities, update_before_add=False)

--- a/custom_components/bull/translations/en.json
+++ b/custom_components/bull/translations/en.json
@@ -7,6 +7,16 @@
             }
         }
     },
+    "device_automation": {
+        "trigger_type": {
+            "work_state_idle": "Work state: idle",
+            "work_state_charging": "Work state: charging",
+            "work_state_gun_inserted_not_activated": "Work state: gun inserted not activated",
+            "work_state_gun_inserted_activated": "Work state: gun inserted activated",
+            "gun_state_unplugged": "Gun state: unplugged",
+            "gun_state_plugged": "Gun state: plugged"
+        }
+    },
     "config": {
         "error": {
             "connection_failed": "Network unreachable",

--- a/custom_components/bull/translations/en.json
+++ b/custom_components/bull/translations/en.json
@@ -1,5 +1,12 @@
 {
     "title": "Bull IoT",
+    "entity": {
+        "binary_sensor": {
+            "connectivity": {
+                "name": "Connectivity"
+            }
+        }
+    },
     "config": {
         "error": {
             "connection_failed": "Network unreachable",

--- a/custom_components/bull/translations/zh-Hans.json
+++ b/custom_components/bull/translations/zh-Hans.json
@@ -1,5 +1,12 @@
 {
     "title": "Bull IoT",
+    "entity": {
+        "binary_sensor": {
+            "connectivity": {
+                "name": "连通性"
+            }
+        }
+    },
     "config": {
         "error": {
             "connection_failed": "通讯异常",

--- a/custom_components/bull/translations/zh-Hans.json
+++ b/custom_components/bull/translations/zh-Hans.json
@@ -7,6 +7,16 @@
             }
         }
     },
+    "device_automation": {
+        "trigger_type": {
+            "work_state_idle": "充电状态：未工作",
+            "work_state_charging": "充电状态：充电中",
+            "work_state_gun_inserted_not_activated": "充电状态：已插枪未激活",
+            "work_state_gun_inserted_activated": "充电状态：已插枪已激活",
+            "gun_state_unplugged": "插枪状态：未插枪",
+            "gun_state_plugged": "插枪状态：已插枪"
+        }
+    },
     "config": {
         "error": {
             "connection_failed": "通讯异常",


### PR DESCRIPTION
1、支持了添加支持 7kW交流充电桩(乐享智联款)
这个充电桩的状态信息变成了多个层级的(看代码似乎以前的设备都是只有一层？)，所以改了比较多
```json
{
   "DeviceRealInfo": {
       “EnergyUsed”: “xxx”
    }
}
```
2、为所有设备添加了一个通用`连通性`的实体，通过`连通性`实体的详细可以看到所有的设备属性方便调试

<img width="529" height="444" alt="image" src="https://github.com/user-attachments/assets/b7e6487a-6ed4-4430-90e1-bed294dfa40f" />

