### PR TITLE
Ignore stale MQTT status updates

### DIFF
--- a/custom_components/bull/api.py
+++ b/custom_components/bull/api.py
@@ -80,6 +80,7 @@ class BullDevice:
         self.identifier_values = {}
         self.raw_info = {}
         self.raw_device_info = {}
+        self._last_status_time = None
         self._connectivity_entity = None
 
     @property
@@ -516,6 +517,24 @@ class BullApi:
             elif db.get("method") == "thing.status":
                 iot_id = db["params"]["iotId"]
                 info = db["params"]["status"]
+                status_time = info.get("time")
+                device = self.device_list.get(iot_id)
+                if (
+                    device
+                    and status_time is not None
+                    and device._last_status_time is not None
+                    and status_time < device._last_status_time
+                ):
+                    _LOGGER.debug(
+                        "Ignore stale MQTT status: iot_id=%s status=%s time=%s last_time=%s",
+                        iot_id,
+                        info["value"],
+                        status_time,
+                        device._last_status_time,
+                    )
+                    return
+                if device and status_time is not None:
+                    device._last_status_time = status_time
                 cb(iot_id, "status", info["value"])
 
         client = mqtt.Client(client_id=clientId)


### PR DESCRIPTION
## Summary

- Track the latest MQTT `thing.status` timestamp per device.
- Ignore older status messages so stale offline updates do not override newer online updates.
- Keep property messages and unknown MQTT methods from changing device availability implicitly.

## Root Cause

Issue #14 shows `status=1` arriving with a newer timestamp, followed immediately by `status=3` with an older timestamp. The integration currently applies MQTT status updates in receive order, so the stale offline update can leave Home Assistant entities unavailable even while the device continues reporting properties.

## Validation

- `python3 -m compileall -q custom_components/bull`
- Simulated the issue ordering and confirmed the older `status=3` update is ignored after a newer `status=1`.